### PR TITLE
feat: Add MyTournaments page to display user's tournaments (#124)

### DIFF
--- a/src/AppRoutes.jsx
+++ b/src/AppRoutes.jsx
@@ -29,6 +29,12 @@ import PlayerProfile from "./AtomicComponents/pages/Player/PlayerProfile/PlayerP
 import OrganizerCommonLayout from "./AtomicComponents/pages/CommonLayouts/OrganizerCommonLayout/OrganizerCommonLayout";
 import { Overview } from "./AtomicComponents/organisms/Overview/Overview";
 import { Settings } from "./AtomicComponents/organisms/Settings/Settings";
+import { PlayerTeams } from "./AtomicComponents/pages/Player/PlayerTeams/PlayerTeams";
+import { TeamDetails } from "./AtomicComponents/pages/Player/TeamDetails/TeamDetails";
+import { MyTeam } from "./AtomicComponents/pages/Player/MyTeam/MyTeam";
+import { TournamentRegistration } from "./AtomicComponents/pages/Player/TournamentRegistration/TournamentRegistration";
+import { MyTournaments } from "./AtomicComponents/pages/Player/MyTournaments/MyTournaments";
+import { TeamTournamentRounds } from "./AtomicComponents/pages/Player/TeamTournamentRounds/TeamTournamentRounds";
 import OrganizerProfile from "./AtomicComponents/pages/Organizer/OrganizerProfile/OrganizerProfile";
 
 const AppRoutes = () => {
@@ -151,6 +157,25 @@ const AppRoutes = () => {
                     auth?.isLeader ? <AssignPlayer /> : <Navigate to="/" />
                   }
                 /> */}
+                <Route path="teams">
+                  <Route index element={<PlayerTeams />} />
+                  <Route path=":teamId" element={<TeamDetails />} />
+                </Route>
+                <Route path="my-team" element={<MyTeam />} />
+                <Route path="tournaments">
+                  <Route 
+                    path="registration" 
+                    element={auth?.isLeader ? <TournamentRegistration /> : <Navigate to="/" />} 
+                  />
+                  <Route 
+                    path="my-tournaments" 
+                    element={<MyTournaments />} 
+                  />
+                  <Route 
+                    path=":tournamentId/rounds" 
+                    element={<TeamTournamentRounds />} 
+                  />
+                </Route>
               </Route>
             </Route>
           </Route>

--- a/src/AtomicComponents/organisms/Sidebar/DasrsSidebar.jsx
+++ b/src/AtomicComponents/organisms/Sidebar/DasrsSidebar.jsx
@@ -83,17 +83,18 @@ const DasrsSidebar = ({ isOpened = false, onToggle = () => {}, data = [] }) => {
       setSelectedItem("/" + activeItem);
     }
 
-    // Auto-expand submenu if current route matches any submenu item
-    const matchedParent = data.find((item) =>
-      item.subMenu?.some((sub) => location.pathname.includes(sub.link))
-    );
+    // Add null check for data array
+    if (data && data.length > 0) {
+      // Auto-expand submenu if current route matches any submenu item
+      const matchedParent = data.find((item) =>
+        item?.subMenu?.some((sub) => location.pathname.includes(sub.link))
+      );
 
-    if (matchedParent && activeSubmenu !== matchedParent.item) {
-      setActiveSubmenu(matchedParent.item);
+      if (matchedParent && activeSubmenu !== matchedParent.item) {
+        setActiveSubmenu(matchedParent.item);
+      }
     }
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [location.pathname]); // Add proper dependency
 
   return (
     <>
@@ -126,7 +127,9 @@ const DasrsSidebar = ({ isOpened = false, onToggle = () => {}, data = [] }) => {
                   text={`${TruncateText("Welcome Back", 18)}`}
                   isVisible={isOpened}
                 />
-                {auth?.isLeader && <span className="text-yellow-500">Leader</span>}
+                {auth?.isLeader && (
+                  <span className="text-yellow-500">Leader</span>
+                )}
               </h1>
             </motion.span>
 

--- a/src/AtomicComponents/pages/CommonLayouts/PlayerCommonLayout/PlayerCommonLayout.jsx
+++ b/src/AtomicComponents/pages/CommonLayouts/PlayerCommonLayout/PlayerCommonLayout.jsx
@@ -14,6 +14,7 @@ import PropTypes from "prop-types";
 import { Outlet } from "react-router-dom";
 import DasrsSidebar from "@/AtomicComponents/organisms/Sidebar/DasrsSidebar";
 import useAuth from "@/hooks/useAuth";
+import { Users, ListIcon } from "lucide-react"; // Import ListIcon
 
 const PlayerCommonLayout = () => {
   const isMobile = useMediaQuery({ maxWidth: 768 });
@@ -22,7 +23,7 @@ const PlayerCommonLayout = () => {
 
   const navBarIconColor = "#FAF9F6";
   const iconWidth = 28;
-  //   const subIconWidth = 20;
+  const subIconWidth = 20;
 
   const sidebarData = [
     {
@@ -36,19 +37,39 @@ const PlayerCommonLayout = () => {
       link: "/my-profile",
     },
     {
-      item: "Rounds",
-      icon: <TournamentIcon color={navBarIconColor} width={iconWidth} />,
-      link: "/rounds",
+      item: "Teams",
+      icon: <Users color={navBarIconColor} width={iconWidth} />,
+      subMenu: [
+        {
+          item: "Team List",
+          icon: <ListIcon color={navBarIconColor} width={subIconWidth} />,
+          link: "/teams",
+        },
+        {
+          item: "My Team",
+          icon: <Users color={navBarIconColor} width={subIconWidth} />,
+          link: "/my-team",
+        },
+      ],
     },
-    // ...(auth?.isLeader
-    //   ? [
-    //       {
-    //         item: "Assign Player",
-    //         icon: <UserIcon color={navBarIconColor} width={iconWidth} />,
-    //         link: "/assign-player",
-    //       },
-    //     ]
-    //   : []),
+    {
+      item: "Tournaments",
+      icon: <TournamentIcon color={navBarIconColor} width={iconWidth} />,
+      subMenu: [
+        {
+          item: "Registration",
+          icon: <ListIcon color={navBarIconColor} width={subIconWidth} />,
+          link: "/tournaments/registration",
+          isLeaderOnly: true,
+        },
+        {
+          item: "My Tournaments",
+          icon: <TournamentIcon color={navBarIconColor} width={subIconWidth} />,
+          link: "/tournaments/my-tournaments",
+        },
+      ],
+    },
+    ,
   ];
 
   useEffect(() => {

--- a/src/AtomicComponents/pages/Player/MyTeam/MyTeam.jsx
+++ b/src/AtomicComponents/pages/Player/MyTeam/MyTeam.jsx
@@ -1,0 +1,450 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useLocation } from "react-router-dom";
+import { apiClient } from "@/config/axios/axios";
+import useAuth from "@/hooks/useAuth";
+import useRefreshToken from "@/hooks/useRefreshToken";
+import { Crown, Trash2, UserCog } from "lucide-react";
+import { toast } from "react-hot-toast";
+import Spinner from "@/AtomicComponents/atoms/Spinner/Spinner";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/AtomicComponents/atoms/shadcn/card";
+import { Badge } from "@/AtomicComponents/atoms/shadcn/badge";
+import { Button } from "@/AtomicComponents/atoms/shadcn/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/AtomicComponents/atoms/shadcn/dialog";
+
+export const MyTeam = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { auth, setAuth } = useAuth();
+  const refresh = useRefreshToken();
+  const [team, setTeam] = useState(null);
+  const [members, setMembers] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isLeader, setIsLeader] = useState(false);
+  const [confirmDialogOpen, setConfirmDialogOpen] = useState(false);
+  const [memberToRemove, setMemberToRemove] = useState(null);
+  const [leadershipDialogOpen, setLeadershipDialogOpen] = useState(false);
+  const [newLeader, setNewLeader] = useState(null);
+  const [leaveTeamDialogOpen, setLeaveTeamDialogOpen] = useState(false);
+  const [deleteTeamDialogOpen, setDeleteTeamDialogOpen] = useState(false);
+
+  const fetchTeamData = async () => {
+    // Use either the auth teamId or the one from navigation state
+    const teamIdToUse = location.state?.newTeamId || auth?.teamId;
+
+    if (!teamIdToUse) {
+      setIsLoading(false);
+      return;
+    }
+
+    try {
+      setIsLoading(true);
+      const [teamResponse, membersResponse] = await Promise.all([
+        apiClient.get(`teams/${auth.teamId}`),
+        apiClient.get(`teams/members/${auth.teamId}`),
+      ]);
+
+      setTeam(teamResponse.data.data);
+      setMembers(membersResponse.data.data || []);
+
+      // Check if current user is leader
+      const currentUserMember = membersResponse.data.data?.find(
+        (member) => member.id === auth.id
+      );
+      setIsLeader(currentUserMember?.is_leader || false);
+    } catch (error) {
+      console.error("Error fetching team data:", error);
+      toast.error("Failed to fetch team data");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    // Always fetch team data when component mounts
+    fetchTeamData();
+  }, []); // Empty dependency array to run only on mount
+
+  useEffect(() => {
+    // Also fetch when teamId changes
+    if (auth?.teamId) {
+      fetchTeamData();
+    }
+  }, [auth?.teamId]);
+
+  const handleRemoveMemberClick = (member) => {
+    setMemberToRemove(member);
+    setConfirmDialogOpen(true);
+  };
+
+  const handleRemoveMember = async () => {
+    if (!isLeader || !memberToRemove) return;
+
+    try {
+      await apiClient.delete(`teams/remove-members`, {
+        params: {
+          teamId: auth.teamId,
+          memberId: memberToRemove.id,
+        },
+      });
+
+      toast.success("Member removed successfully");
+      setConfirmDialogOpen(false);
+      setMemberToRemove(null);
+      fetchTeamData(); // Refresh the team data
+    } catch (error) {
+      console.error("Error removing member:", error);
+      toast.error("Failed to remove member");
+    }
+  };
+
+  const handleChangeLeaderClick = (member) => {
+    setNewLeader(member);
+    setLeadershipDialogOpen(true);
+  };
+
+  const handleChangeLeader = async () => {
+    if (!isLeader || !newLeader) return;
+
+    try {
+      await apiClient.put(`teams/leadership/${auth.teamId}/${newLeader.id}`);
+
+      toast.success("Team leadership transferred successfully");
+      setLeadershipDialogOpen(false);
+      setNewLeader(null);
+      fetchTeamData(); // Refresh the team data
+    } catch (error) {
+      console.error("Error changing team leader:", error);
+      toast.error("Failed to transfer team leadership");
+    }
+  };
+
+  const handleLeaveTeam = async () => {
+    try {
+      // First leave the team
+      await apiClient.delete(`teams/${auth.teamId}/leave`, {
+        params: {
+          playerId: auth.id,
+        },
+      });
+
+      // Then refresh the tokens to get updated user data
+      await refresh();
+
+      toast.success("Successfully left the team");
+      setLeaveTeamDialogOpen(false);
+
+      // Reset local team-related states
+      setTeam(null);
+      setMembers([]);
+      setIsLeader(false);
+
+      // Update auth context to remove teamId
+      setAuth((prev) => ({
+        ...prev,
+        teamId: null,
+        isLeader: false,
+      }));
+
+      // Navigate to teams page
+      navigate("/teams", { replace: true });
+    } catch (error) {
+      console.error("Error leaving team:", error);
+      toast.error("Failed to leave team");
+
+      if (error.response?.status === 401) {
+        toast.error("Session expired. Please log in again.");
+      }
+    }
+  };
+
+  const handleDeleteTeam = async () => {
+    try {
+      await apiClient.delete(`teams/delete-team/${auth.teamId}`, {
+        params: {
+          leaderId: auth.id,
+        },
+      });
+
+      // Refresh token to get updated user data
+      await refresh();
+
+      toast.success("Team deleted successfully");
+
+      // Reset local team-related states
+      setTeam(null);
+      setMembers([]);
+      setIsLeader(false);
+
+      // Update auth context to remove teamId
+      setAuth((prev) => ({
+        ...prev,
+        teamId: null,
+        isLeader: false,
+      }));
+
+      // Navigate to teams page
+      navigate("/teams", { replace: true });
+    } catch (error) {
+      console.error("Error deleting team:", error);
+      toast.error("Failed to delete team");
+    }
+  };
+
+  const renderTeamStatusBadge = (memberCount) => {
+    const isFull = memberCount === 5;
+    return (
+      <Badge
+        variant="outline"
+        className={
+          isFull ? "bg-red-100 text-red-800" : "bg-green-100 text-green-800"
+        }
+      >
+        {isFull ? "Full" : "Open"}
+      </Badge>
+    );
+  };
+
+  if (isLoading) return <Spinner />;
+  if (!auth?.teamId)
+    return (
+      <div className="flex items-center justify-center h-64">
+        <p className="text-gray-500">You are not part of any team</p>
+      </div>
+    );
+  if (!team)
+    return (
+      <div className="flex items-center justify-center h-64">
+        <p className="text-gray-500">You are not part of any team</p>
+      </div>
+    );
+
+  return (
+    <>
+      <div className="container mx-auto p-4">
+        <Card>
+          <CardHeader>
+            <div className="flex justify-between items-center">
+              <div>
+                <CardTitle className="text-2xl">{team.name}</CardTitle>
+                <span className="text-gray-500">Tag: {team.tag}</span>
+              </div>
+              <div className="flex gap-2 items-center">
+                {renderTeamStatusBadge(team.member_count)}
+                {team.status && (
+                  <Badge
+                    variant={
+                      team.status === "ACTIVE" ? "success" : "destructive"
+                    }
+                  >
+                    {team.status}
+                  </Badge>
+                )}
+                {!isLeader && ( // Only show leave button for non-leaders
+                  <Button
+                    variant="destructive"
+                    size="sm"
+                    onClick={() => setLeaveTeamDialogOpen(true)}
+                  >
+                    Leave Team
+                  </Button>
+                )}
+                {isLeader && team.member_count === 1 && (
+                  <Button
+                    variant="destructive"
+                    size="sm"
+                    onClick={() => setDeleteTeamDialogOpen(true)}
+                  >
+                    Delete Team
+                  </Button>
+                )}
+              </div>
+            </div>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-4">
+              <div>
+                <h3 className="font-semibold text-lg mb-2">
+                  Team Members ({team.member_count}/5)
+                </h3>
+                <div className="space-y-2">
+                  {members.map((member) => (
+                    <div
+                      key={member.id}
+                      className={`flex items-center justify-between p-3 rounded-lg transition-colors ${
+                        member.is_leader
+                          ? "bg-yellow-50 hover:bg-yellow-100 border border-yellow-200"
+                          : "bg-gray-50 hover:bg-gray-100"
+                      }`}
+                    >
+                      <div className="flex items-center gap-2">
+                        {member.is_leader && (
+                          <Crown className="h-5 w-5 text-yellow-500" />
+                        )}
+                        <div>
+                          <p className="font-medium">{member.full_name}</p>
+                          <p className="text-sm text-gray-500">
+                            {member.email}
+                          </p>
+                        </div>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <Badge variant="outline">
+                          {member.is_leader ? "Leader" : "Member"}
+                        </Badge>
+                        {isLeader && !member.is_leader && (
+                          <div className="flex gap-1">
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="h-8 w-8 text-blue-500 hover:text-blue-700 hover:bg-blue-100"
+                              onClick={() => handleChangeLeaderClick(member)}
+                              title="Transfer Leadership"
+                            >
+                              <UserCog className="h-4 w-4" />
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="h-8 w-8 text-red-500 hover:text-red-700 hover:bg-red-100"
+                              onClick={() => handleRemoveMemberClick(member)}
+                              title="Remove Member"
+                            >
+                              <Trash2 className="h-4 w-4" />
+                            </Button>
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Remove Member Dialog */}
+      <Dialog open={confirmDialogOpen} onOpenChange={setConfirmDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Remove Team Member</DialogTitle>
+          </DialogHeader>
+          <p>
+            Are you sure you want to remove{" "}
+            <span className="font-medium">{memberToRemove?.full_name}</span>{" "}
+            from the team?
+          </p>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setConfirmDialogOpen(false)}
+            >
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={handleRemoveMember}>
+              Remove
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Change Leader Dialog */}
+      <Dialog
+        open={leadershipDialogOpen}
+        onOpenChange={setLeadershipDialogOpen}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Transfer Team Leadership</DialogTitle>
+          </DialogHeader>
+          <p>
+            Are you sure you want to transfer team leadership to{" "}
+            <span className="font-medium">{newLeader?.full_name}</span>?
+          </p>
+          <p className="text-sm text-gray-500">
+            You will become a regular team member after this action.
+          </p>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setLeadershipDialogOpen(false)}
+            >
+              Cancel
+            </Button>
+            <Button variant="default" onClick={handleChangeLeader}>
+              Transfer Leadership
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Leave Team Dialog */}
+      <Dialog open={leaveTeamDialogOpen} onOpenChange={setLeaveTeamDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Leave Team</DialogTitle>
+          </DialogHeader>
+          <p>
+            Are you sure you want to leave team{" "}
+            <span className="font-medium">{team?.name}</span>?
+          </p>
+          <p className="text-sm text-red-500">
+            This action cannot be undone. You will need to be invited back to
+            rejoin the team.
+          </p>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setLeaveTeamDialogOpen(false)}
+            >
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={handleLeaveTeam}>
+              Leave Team
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete Team Dialog */}
+      <Dialog
+        open={deleteTeamDialogOpen}
+        onOpenChange={setDeleteTeamDialogOpen}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete Team</DialogTitle>
+          </DialogHeader>
+          <p>
+            Are you sure you want to delete this team? This action cannot be
+            undone.
+          </p>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setDeleteTeamDialogOpen(false)}
+            >
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={handleDeleteTeam}>
+              Delete Team
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+};
+
+export default MyTeam;

--- a/src/AtomicComponents/pages/Player/MyTournaments/MyTournaments.jsx
+++ b/src/AtomicComponents/pages/Player/MyTournaments/MyTournaments.jsx
@@ -1,0 +1,109 @@
+import React, { useState, useEffect } from "react";
+import { apiClient } from "@/config/axios/axios";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardFooter,
+} from "@/AtomicComponents/atoms/shadcn/card";
+import { Badge } from "@/AtomicComponents/atoms/shadcn/badge";
+import { toast } from "sonner";
+import Spinner from "@/AtomicComponents/atoms/Spinner/Spinner";
+import useAuth from "@/hooks/useAuth";
+import { Button } from "@/AtomicComponents/atoms/shadcn/button";
+import { useNavigate } from "react-router-dom";
+
+export const MyTournaments = () => {
+  const [tournaments, setTournaments] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const { auth } = useAuth();
+  const navigate = useNavigate();
+
+  // Display values for pagination
+
+  const fetchMyTournaments = async () => {
+    try {
+      setIsLoading(true);
+      const response = await apiClient.get(
+        "tournaments/team/" + auth?.teamId,
+        {}
+      );
+
+      if (response.data.http_status === 200) {
+        const data = response.data.data;
+        setTournaments(data || []);
+      }
+    } catch (error) {
+      console.error("Error fetching tournaments:", error);
+      toast.error(error.response.data.error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleViewRounds = (tournamentId) => {
+    navigate(`/tournaments/${tournamentId}/rounds`);
+  };
+
+  useEffect(() => {
+    fetchMyTournaments();
+  }, []);
+
+  if (isLoading) return <Spinner />;
+
+  return (
+    <div className="container mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-6">My Tournaments</h1>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        {tournaments.map((tournament) => (
+          <Card key={tournament.tournament_id}>
+            <CardHeader>
+              <CardTitle className="flex justify-between items-center">
+                <span
+                  className="truncate max-w-[200px]"
+                  title={tournament.tournament_name}
+                >
+                  {tournament.tournament_name}
+                </span>
+                <Badge className="mt-2">{tournament.status}</Badge>
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-2">
+                <p className="text-sm text-gray-500  truncate">
+                  {tournament.tournament_context}
+                </p>
+                <div className="flex justify-between items-center text-sm">
+                  <span>
+                    Start:{new Date(tournament.start_date).toLocaleDateString()}
+                  </span>
+                  <span>
+                    End: {new Date(tournament.end_date).toLocaleDateString()}
+                  </span>
+                </div>
+              </div>
+            </CardContent>
+            <CardFooter className="p-4">
+              <Button
+                variant="outline"
+                className="w-full"
+                onClick={() => handleViewRounds(tournament.tournament_id)}
+              >
+                View Rounds
+              </Button>
+            </CardFooter>
+          </Card>
+        ))}
+      </div>
+
+      {tournaments.length === 0 && (
+        <div className="text-center text-gray-500 mt-8">
+          You haven't joined any tournaments yet
+        </div>
+      )}
+    </div>
+  );
+};
+

--- a/src/AtomicComponents/pages/Player/PlayerMatches/PlayerMatches.jsx
+++ b/src/AtomicComponents/pages/Player/PlayerMatches/PlayerMatches.jsx
@@ -165,9 +165,9 @@ const PlayerMatches = () => {
         const response = await apiClient.get(`teams/members/${auth?.teamId}`);
 
         if (response.status === 200) {
-          setTeamMember(response.data);
+          setTeamMember(response.data.data);
           setPlayerOptions(
-            response.data.map((member) => ({
+            response.data.data.map((member) => ({
               value: member.id,
               label: member.full_name,
             }))
@@ -463,21 +463,15 @@ const PlayerMatches = () => {
 
             {/* Select slot */}
             <div className="">
-              <label className="block mb-1">Select empty slot</label>
-              {!selectedMatch?.match_team ||
-              selectedMatch.match_team.filter((m) => !m.player_id).length ===
-                0 ? (
-                <p className="text-md text-red-500">
-                  All slots are already assigned
-                </p>
+              <label className="block mb-1">Select slot</label>
+              {!selectedMatch?.match_team || selectedMatch.match_team.length === 0 ? (
+                <p className="text-md text-red-500">No slots available</p>
               ) : (
                 <Select
-                  options={selectedMatch.match_team
-                    .filter((m) => !m.player_id)
-                    .map((m) => ({
-                      value: m.match_team_id,
-                      label: `Slot ${m.match_team_id}`,
-                    }))}
+                  options={selectedMatch.match_team.map((m, index) => ({
+                    value: m.match_team_id,
+                    label: `Slot ${index + 1}${m.player_id ? ` (Assigned to ${m.player_name || 'Someone'})` : ''}`,
+                  }))}
                   placeHolder="Select slot"
                   onChange={(e) =>
                     setAssignData((prev) => ({
@@ -507,7 +501,11 @@ const PlayerMatches = () => {
             <div className="text-center">
               <Button
                 disabled={!assignData.assignee || !assignData.matchTeamid}
-                content="Assign Player"
+                content={
+                  selectedMatch?.match_team?.find(m => m.match_team_id === assignData.matchTeamid)?.player_id 
+                  ? "Reassign Player" 
+                  : "Assign Player"
+                }
                 type="submit"
               />
             </div>

--- a/src/AtomicComponents/pages/Player/PlayerTeams/PlayerTeams.jsx
+++ b/src/AtomicComponents/pages/Player/PlayerTeams/PlayerTeams.jsx
@@ -1,0 +1,176 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Plus } from "lucide-react";
+import { useTeamManagement } from "../../../../hooks/useTeamManagement";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/AtomicComponents/atoms/shadcn/card";
+import { Button } from "@/AtomicComponents/atoms/shadcn/button";
+import { Badge } from "@/AtomicComponents/atoms/shadcn/badge";
+import Spinner from "@/AtomicComponents/atoms/Spinner/Spinner";
+import {
+  Modal,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+} from "@/AtomicComponents/organisms/Modal/Modal";
+
+export const PlayerTeams = () => {
+  const { teams, isLoading, createTeam } = useTeamManagement();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [formData, setFormData] = useState({ name: "", tag: "" });
+  const navigate = useNavigate();
+
+  const handleCreateTeam = async (e) => {
+    e.preventDefault();
+    const newTeamId = await createTeam(formData.name, formData.tag);
+    if (newTeamId) {
+      // Navigate to my-team page with replace to prevent back navigation
+      navigate("/my-team", { replace: true });
+    }
+    setIsModalOpen(false);
+    setFormData({ name: "", tag: "" });
+  };
+
+  const handleViewTeam = (teamId) => {
+    navigate(`/teams/${teamId}`);
+  };
+
+  const renderTeamStatusBadge = (memberCount) => {
+    const isFull = memberCount === 5;
+    return (
+      <Badge
+        variant="outline"
+        className={
+          isFull ? "bg-red-100 text-red-800" : "bg-green-100 text-green-800"
+        }
+      >
+        {isFull ? "Full" : "Open"}
+      </Badge>
+    );
+  };
+
+  return (
+    <>
+      {isLoading && <Spinner />}
+
+      <div className="container mx-auto p-4">
+        <div className="flex justify-between items-center mb-6">
+          <h1 className="text-2xl font-bold">My Teams</h1>
+          <Button
+            onClick={() => setIsModalOpen(true)}
+            className="px-4 py-2 h-10"
+          >
+            <Plus className="mr-2 h-5 w-5" /> Create Team
+          </Button>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {teams.map((team) => (
+            <Card
+              key={team.id}
+              className="cursor-pointer hover:shadow-lg transition-shadow"
+              onClick={() => handleViewTeam(team.id)}
+            >
+              <CardHeader className="pb-2">
+                <div className="flex justify-between items-start">
+                  <CardTitle className="text-lg">{team.name}</CardTitle>
+                  {renderTeamStatusBadge(team.member_count || 0)}
+                </div>
+              </CardHeader>
+              <CardContent>
+                <div className="space-y-2">
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm text-gray-500">Tag:</span>
+                    <span className="font-medium bg-gray-100 px-2 py-1 rounded text-sm">
+                      {team.tag}
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm text-gray-500">Members:</span>
+                    <span className="font-medium">
+                      {team.member_count || 0}/5
+                    </span>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+
+        {/* Enhanced Modal UI */}
+        <Modal
+          show={isModalOpen}
+          onHide={() => setIsModalOpen(false)}
+          size="sm"
+        >
+          <ModalHeader content="Create New Team" className="border-b pb-4" />
+          <ModalBody className="py-6">
+            <form id="createTeamForm" onSubmit={handleCreateTeam}>
+              <div className="space-y-6">
+                <div className="space-y-2">
+                  <label className="text-sm font-semibold text-gray-700">
+                    Team Name
+                  </label>
+                  <input
+                    type="text"
+                    className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                    placeholder="Enter team name"
+                    value={formData.name}
+                    onChange={(e) =>
+                      setFormData((prev) => ({
+                        ...prev,
+                        name: e.target.value,
+                      }))
+                    }
+                    required
+                  />
+                </div>
+                <div className="space-y-2">
+                  <label className="text-sm font-semibold text-gray-700">
+                    Team Tag
+                  </label>
+                  <input
+                    type="text"
+                    className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                    placeholder="Enter team tag"
+                    value={formData.tag}
+                    onChange={(e) =>
+                      setFormData((prev) => ({
+                        ...prev,
+                        tag: e.target.value,
+                      }))
+                    }
+                    required
+                  />
+                  <p className="text-sm text-gray-500 mt-1">
+                    A short identifier for your team (e.g., "TSM", "C9")
+                  </p>
+                </div>
+              </div>
+            </form>
+          </ModalBody>
+          <ModalFooter className="border-t py-4 px-4 space-x-3">
+            <Button
+              type="submit"
+              form="createTeamForm"
+              className="px-4 py-2 h-10"
+            >
+              Create Team
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => setIsModalOpen(false)}
+              className="px-4 py-2 h-10"
+            >
+              Cancel
+            </Button>
+          </ModalFooter>
+        </Modal>
+      </div>
+    </>
+  );
+};

--- a/src/AtomicComponents/pages/Player/TeamDetails/TeamDetails.jsx
+++ b/src/AtomicComponents/pages/Player/TeamDetails/TeamDetails.jsx
@@ -1,0 +1,189 @@
+import { useEffect, useState } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import { apiClient } from "@/config/axios/axios";
+import useAuth from "@/hooks/useAuth";
+import useRefreshToken from "@/hooks/useRefreshToken";
+import { toast } from "react-hot-toast";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/AtomicComponents/atoms/shadcn/card";
+import { Button } from "@/AtomicComponents/atoms/shadcn/button";
+import { Badge } from "@/AtomicComponents/atoms/shadcn/badge";
+import { Crown, UserPlus } from "lucide-react";
+import Spinner from "@/AtomicComponents/atoms/Spinner/Spinner";
+
+export const TeamDetails = () => {
+  const { teamId } = useParams();
+  const { auth, setAuth } = useAuth();
+  const refresh = useRefreshToken();
+  const [team, setTeam] = useState(null);
+  const [members, setMembers] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isJoining, setIsJoining] = useState(false);
+  const navigate = useNavigate();
+
+  const fetchTeamData = async () => {
+    try {
+      setIsLoading(true);
+      const [teamResponse, membersResponse] = await Promise.all([
+        apiClient.get(`teams/${teamId}`),
+        apiClient.get(`teams/members/${teamId}`)
+      ]);
+
+      setTeam(teamResponse.data.data);
+      setMembers(membersResponse.data.data || []);
+    } catch (error) {
+      console.error("Error fetching team data:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleJoinTeam = async () => {
+    try {
+      setIsJoining(true);
+      
+      // Call join team API with the correct endpoint format
+      await apiClient.post(`teams/${teamId}/join?playerId=${auth.id}`, '');
+
+      // Refresh token to get updated user data
+      await refresh();
+
+      toast.success("Successfully joined the team");
+      
+      // Refresh team data
+      await fetchTeamData();
+
+      // Update auth context
+      setAuth(prev => ({
+        ...prev,
+        teamId: teamId,
+        isLeader: false
+      }));
+
+      // Navigate to my team page
+      navigate("/my-team", { replace: true });
+    } catch (error) {
+      console.error("Error joining team:", error);
+      toast.error(error.response?.data?.message || "Failed to join team");
+    } finally {
+      setIsJoining(false);
+    }
+  };
+
+  const canJoinTeam = () => {
+    return (
+      !auth?.teamId && // User is not in a team
+      team?.member_count < 5 && // Team is not full
+      team?.status === "ACTIVE" && // Team is active
+      !team?.disqualified // Team is not disqualified
+    );
+  };
+
+  useEffect(() => {
+    fetchTeamData();
+  }, [teamId]);
+
+  const renderTeamStatusBadge = (memberCount) => {
+    const isFull = memberCount === 5;
+    return (
+      <Badge 
+        variant="outline" 
+        className={isFull ? 
+          "bg-red-100 text-red-800" : 
+          "bg-green-100 text-green-800"
+        }
+      >
+        {isFull ? 'Full' : 'Open'}
+      </Badge>
+    );
+  };
+
+  if (isLoading) return <Spinner />;
+  if (!team) return <div>Team not found</div>;
+
+  return (
+    <div className="container mx-auto p-4">
+      <Button
+        variant="outline"
+        onClick={() => navigate("/teams")}
+        className="mb-4"
+      >
+        Back to Teams
+      </Button>
+
+      <Card>
+        <CardHeader>
+          <div className="flex justify-between items-center">
+            <div>
+              <CardTitle className="text-2xl">{team.name}</CardTitle>
+              <span className="text-gray-500">Tag: {team.tag}</span>
+            </div>
+            <div className="flex gap-2 items-center">
+              {renderTeamStatusBadge(team.member_count)}
+              {team.status && (
+                <Badge variant={team.status === "ACTIVE" ? "success" : "destructive"}>
+                  {team.status}
+                </Badge>
+              )}
+              {team.disqualified && (
+                <Badge variant="destructive">Disqualified</Badge>
+              )}
+              {canJoinTeam() && (
+                <Button 
+                  onClick={handleJoinTeam}
+                  disabled={isJoining}
+                  className="ml-2"
+                >
+                  <UserPlus className="h-4 w-4 mr-2" />
+                  {isJoining ? "Joining..." : "Join Team"}
+                </Button>
+              )}
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-4">
+            <div>
+              <h3 className="font-semibold text-lg mb-2">Team Members ({team.member_count}/5)</h3>
+              <div className="space-y-2">
+                {members.map((member) => (
+                  <div
+                    key={member.id}
+                    className={`flex items-center justify-between p-3 rounded-lg transition-colors ${
+                      member.is_leader 
+                        ? 'bg-yellow-50 hover:bg-yellow-100 border border-yellow-200' 
+                        : 'bg-gray-50 hover:bg-gray-100'
+                    }`}
+                  >
+                    <div className="flex items-center gap-2">
+                      {member.is_leader && (
+                        <Crown className="h-5 w-5 text-yellow-500" />
+                      )}
+                      <span className={`font-medium ${member.is_leader ? 'text-yellow-700' : ''}`}>
+                        {member.full_name}
+                      </span>
+                    </div>
+                    {member.is_leader && (
+                      <Badge variant="outline" className="bg-yellow-100 text-yellow-800">
+                        Team Leader
+                      </Badge>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+
+
+
+

--- a/src/AtomicComponents/pages/Player/TeamTournamentRounds/TeamTournamentRounds.jsx
+++ b/src/AtomicComponents/pages/Player/TeamTournamentRounds/TeamTournamentRounds.jsx
@@ -1,0 +1,233 @@
+import React, { useState, useEffect } from "react";
+import { useParams, useNavigate, useLocation } from "react-router-dom";
+import { apiClient, apiAuth } from "@/config/axios/axios";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardFooter,
+} from "@/AtomicComponents/atoms/shadcn/card";
+import { Button } from "@/AtomicComponents/atoms/shadcn/button";
+import { Badge } from "@/AtomicComponents/atoms/shadcn/badge";
+import { toast } from "sonner";
+import Spinner from "@/AtomicComponents/atoms/Spinner/Spinner";
+import useAuth from "@/hooks/useAuth";
+import DasrsPagination from "@/AtomicComponents/molecules/DasrsPagination/DasrsPagination";
+import { Map } from "lucide-react";
+import { Flag } from "lucide-react";
+import { Users } from "lucide-react";
+import { EnvironmentDetails } from "@/AtomicComponents/molecules/CollapsibleDetails/EnvironmentDetails";
+import { MapDetails } from "@/AtomicComponents/molecules/CollapsibleDetails/MapDetails";
+import { ScoreMethodDetails } from "@/AtomicComponents/molecules/CollapsibleDetails/ScoreMethodDetails";
+import { Trophy } from "lucide-react";
+
+export const TeamTournamentRounds = () => {
+  const { tournamentId } = useParams();
+  const { auth } = useAuth();
+  const navigate = useNavigate();
+  const [rounds, setRounds] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [tournament, setTournament] = useState(null);
+
+  // Pagination states
+  const [pageIndex, setPageIndex] = useState(1);
+  const [pageSize, setPageSize] = useState(6);
+  const [totalPages, setTotalPages] = useState(1);
+
+  // Display values for pagination
+  const displayedValues = [6, 12, 18, 24];
+
+  const fetchRounds = async () => {
+    try {
+      setIsLoading(true);
+      const [roundsResponse, tournamentResponse] = await Promise.all([
+        apiClient.get(`rounds/team/${auth.teamId}/tournament/${tournamentId}`, {
+          params: {
+            pageNo: pageIndex - 1, // Convert to 0-based index for API
+            pageSize: pageSize,
+            sortBy: "SORT_BY_ID_ASC",
+          },
+        }),
+        apiClient.get(`tournaments/${tournamentId}`),
+      ]);
+
+      if (roundsResponse.data.http_status === 200) {
+        setRounds(roundsResponse.data.data.rounds || []);
+        setTotalPages(roundsResponse.data.data.total_pages || 1);
+      }
+
+      if (tournamentResponse.data.http_status === 200) {
+        setTournament(tournamentResponse.data.data);
+      }
+    } catch (error) {
+      console.error("Error fetching rounds:", error);
+      toast.error("Failed to fetch rounds");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchRounds();
+  }, [tournamentId, pageIndex, pageSize]);
+
+  const handleViewMatches = (roundId, roundName) => {
+    navigate(`/rounds/${roundId}/matches`, {
+      state: { roundName }, // Pass round name as state
+    });
+  };
+
+  const handleViewLeaderboard = (roundId) => {
+    navigate(`/rounds/${roundId}/leaderboard`);
+  };
+
+  const handleBack = () => {
+    navigate("/tournaments/my-tournaments");
+  };
+
+  // Pagination handlers
+  const handlePagination = (_pageSize, newPageIndex) => {
+    setPageIndex(newPageIndex);
+  };
+
+  const handleChangePageSize = (newSize) => {
+    setPageSize(newSize);
+    setPageIndex(1); // Reset to first page when changing page size
+  };
+
+  if (isLoading) return <Spinner />;
+
+  return (
+    <div className="container mx-auto p-4">
+      <Button variant="outline" onClick={handleBack} className="mb-4">
+        Back to Tournaments
+      </Button>
+
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold">
+          {tournament?.tournament_name || "Tournament Rounds"}
+        </h1>
+        <p className="text-gray-500 mt-2">
+          View all rounds for this tournament
+        </p>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2 mb-4">
+        {rounds.map((round) => (
+          <Card key={round.round_id} className="flex flex-col">
+            <CardHeader>
+              <CardTitle className="flex justify-between items-center">
+                <span
+                  className="truncate max-w-[200px]"
+                  title={round.round_name}
+                >
+                  {round.round_name}
+                </span>
+                <Badge
+                  variant={round.status === "ACTIVE" ? "success" : "secondary"}
+                >
+                  {round.status}
+                </Badge>
+              </CardTitle>
+            </CardHeader>
+
+            <CardContent>
+              <div className="space-y-2">
+                <div className="flex justify-between items-center text-sm">
+                  <span>
+                    Start: {new Date(round.start_date).toLocaleDateString()}
+                  </span>
+                  <span>
+                    End: {new Date(round.end_date).toLocaleDateString()}
+                  </span>
+                </div>
+                {round.description && (
+                  <p className="text-sm text-gray-500">{round.description}</p>
+                )}
+
+                <div className="grid grid-cols-2 gap-x-4 text-sm">
+                  <div className="flex items-center">
+                    <Map className="h-4 w-4 mr-2 text-gray-500" />
+                    <span className="text-muted-foreground">Match Type:</span>
+                  </div>
+                  <span className="text-right font-medium truncate">
+                    {round.match_type_name}
+                  </span>
+
+                  <div className="flex items-center">
+                    <Flag className="h-4 w-4 mr-2 text-gray-500" />
+                    <span className="text-muted-foreground">Finish Type:</span>
+                  </div>
+                  <span className="text-right font-medium truncate">
+                    {round.finish_type}
+                  </span>
+
+                  <div className="flex items-center">
+                    <Users className="h-4 w-4 mr-2 text-gray-500" />
+                    <span className="text-muted-foreground">
+                      Qualification Spots:
+                    </span>
+                  </div>
+                  <span className="text-right">{round.team_limit}</span>
+                </div>
+              </div>
+              <div className="space-y-2 pt-2 border-t">
+                <EnvironmentDetails environmentId={round.environment_id} />
+              </div>
+              <div className="space-y-2 pt-2 border-t">
+                <MapDetails resourceId={round.map_id} />
+              </div>
+              <div className="pt-2 border-t">
+                <ScoreMethodDetails scoredMethodId={round.scored_method_id} />
+              </div>
+            </CardContent>
+
+            <div className="mt-auto">
+              <CardFooter className="p-4 flex flex-col gap-2">
+                <Button
+                  variant="default"
+                  className="w-full"
+                  onClick={() =>
+                    handleViewMatches(round.round_id, round.round_name)
+                  }
+                >
+                  <Users className="mr-2 h-4 w-4" />
+                  View Matches
+                </Button>
+                <Button
+                  variant="outline"
+                  className="w-full"
+                  onClick={() => handleViewLeaderboard(round.round_id)}
+                >
+                  <Trophy className="mr-2 h-4 w-4" />
+                  View Leaderboard
+                </Button>
+              </CardFooter>
+            </div>
+          </Card>
+        ))}
+
+        {rounds.length === 0 && (
+          <div className="col-span-2 text-center text-gray-500 py-8">
+            No rounds found for this tournament
+          </div>
+        )}
+      </div>
+
+      {rounds.length > 0 && (
+        <DasrsPagination
+          pageSize={pageSize}
+          pageIndex={pageIndex}
+          handlePagination={handlePagination}
+          handleChangePageSize={handleChangePageSize}
+          page={pageIndex}
+          count={totalPages}
+          displayedValues={displayedValues}
+        />
+      )}
+    </div>
+  );
+};
+
+

--- a/src/AtomicComponents/pages/Player/TournamentRegistration/TournamentRegistration.jsx
+++ b/src/AtomicComponents/pages/Player/TournamentRegistration/TournamentRegistration.jsx
@@ -1,0 +1,202 @@
+import React, { useState, useEffect } from "react";
+import { apiClient } from "@/config/axios/axios";
+import { Button } from "@/AtomicComponents/atoms/shadcn/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/AtomicComponents/atoms/shadcn/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/AtomicComponents/atoms/shadcn/dialog";
+import { Badge } from "@/AtomicComponents/atoms/shadcn/badge";
+import { toast } from "sonner";
+import Spinner from "@/AtomicComponents/atoms/Spinner/Spinner";
+import useAuth from "@/hooks/useAuth";
+import DasrsPagination from "@/AtomicComponents/molecules/DasrsPagination/DasrsPagination";
+
+export const TournamentRegistration = () => {
+  const [tournaments, setTournaments] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const { auth } = useAuth();
+  const [confirmDialogOpen, setConfirmDialogOpen] = useState(false);
+  const [selectedTournament, setSelectedTournament] = useState(null);
+
+  // Pagination states
+  const [pageIndex, setPageIndex] = useState(1);
+  const [pageSize, setPageSize] = useState(6);
+  const [totalPages, setTotalPages] = useState(1);
+
+  // Display values for pagination
+  const displayedValues = [6, 12, 18, 24];
+
+  const fetchActiveTournaments = async () => {
+    try {
+      setIsLoading(true);
+      const response = await apiClient.get("tournaments", {
+        params: {
+          pageNo: pageIndex - 1,
+          pageSize,
+          status: "ACTIVE",
+          sortBy: "SORT_BY_ID_ASC",
+        },
+      });
+
+      if (response.data.http_status === 200) {
+        const data = response.data.data;
+        setTournaments(data.content || []);
+        setTotalPages(data.total_pages || 1);
+      }
+    } catch (error) {
+      console.error("Error fetching tournaments:", error);
+      toast.error("Failed to fetch tournaments");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleRegisterClick = (tournament) => {
+    setSelectedTournament(tournament);
+    setConfirmDialogOpen(true);
+  };
+
+  const handleRegisterTeam = async () => {
+    if (!selectedTournament) return;
+
+    try {
+      await apiClient.post(
+        `tournaments/register-team/${selectedTournament.tournament_id}/${auth.teamId}`
+      );
+      toast.success("Successfully registered for tournament");
+      setConfirmDialogOpen(false);
+      setSelectedTournament(null);
+      // Refresh the tournaments list
+      fetchActiveTournaments();
+    } catch (error) {
+      console.error("Error registering team:", error);
+      toast.error(error.response?.data?.message || "Failed to register team");
+    }
+  };
+
+  // Pagination handlers
+  const handlePagination = (_pageSize, newPageIndex) => {
+    setPageIndex(newPageIndex);
+  };
+
+  const handleChangePageSize = (newSize) => {
+    setPageSize(newSize);
+    setPageIndex(1); // Reset to first page when changing page size
+  };
+
+  useEffect(() => {
+    fetchActiveTournaments();
+  }, [pageIndex, pageSize]); // Refetch when pagination changes
+
+  if (isLoading) return <Spinner />;
+
+  return (
+    <div className="container mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-6">All Tournaments</h1>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        {tournaments.map((tournament) => (
+          <Card key={tournament.tournament_id}>
+            <CardHeader>
+              <CardTitle className="flex justify-between items-center">
+                <span
+                  className="truncate max-w-[200px]"
+                  title={tournament.tournament_name}
+                >
+                  {tournament.tournament_name}
+                </span>
+                <Badge variant="secondary">
+                  {tournament.team_list?.length || 0}/{tournament.team_number}
+                  Teams
+                </Badge>
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-2">
+                <p className="text-sm text-gray-500 truncate">
+                  {tournament.tournament_context}
+                </p>
+                <div className="flex justify-between items-center text-sm">
+                  <span>
+                    Start:
+                    {new Date(tournament.start_date).toLocaleDateString()}
+                  </span>
+                  <span>
+                    End: {new Date(tournament.end_date).toLocaleDateString()}
+                  </span>
+                </div>
+                <Button
+                  className="w-full mt-4"
+                  onClick={() => handleRegisterClick(tournament)}
+                  disabled={
+                    (tournament.team_list?.length || 0) >=
+                    tournament.team_number
+                  }
+                >
+                  {(tournament.team_list?.length || 0) >= tournament.team_number
+                    ? "Tournament Full"
+                    : "Register Team"}
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {/* Confirmation Dialog */}
+      <Dialog open={confirmDialogOpen} onOpenChange={setConfirmDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Confirm Tournament Registration</DialogTitle>
+          </DialogHeader>
+          <p>
+            Are you sure you want to register your team for{" "}
+            <span className="font-semibold">
+              {selectedTournament?.tournament_name}
+            </span>
+            ?
+          </p>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setConfirmDialogOpen(false)}
+            >
+              Cancel
+            </Button>
+            <Button onClick={handleRegisterTeam}>
+              Register
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {tournaments.length === 0 && (
+        <div className="text-center text-gray-500 mt-8">
+          No active tournaments available
+        </div>
+      )}
+
+      {tournaments.length > 0 && (
+        <DasrsPagination
+          pageSize={pageSize}
+          pageIndex={pageIndex}
+          handlePagination={handlePagination}
+          handleChangePageSize={handleChangePageSize}
+          page={pageIndex}
+          count={totalPages}
+          displayedValues={displayedValues}
+        />
+      )}
+    </div>
+  );
+};
+

--- a/src/hooks/useRefreshToken.jsx
+++ b/src/hooks/useRefreshToken.jsx
@@ -1,6 +1,6 @@
 import useAuth from "./useAuth";
 import { apiAuth } from "@/config/axios/axios";
-import { decryptToken } from "@/utils/CryptoUtils";
+import { decryptToken, encryptToken } from "@/utils/CryptoUtils";
 import Cookies from "js-cookie";
 import { jwtDecode } from "jwt-decode";
 

--- a/src/hooks/useTeamManagement.jsx
+++ b/src/hooks/useTeamManagement.jsx
@@ -1,0 +1,83 @@
+import { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { toast } from "react-hot-toast";
+import useAuth from "./useAuth";
+import { apiClient } from "@/config/axios/axios";
+import useRefreshToken from "./useRefreshToken";
+
+export const useTeamManagement = () => {
+  const [teams, setTeams] = useState([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const { auth } = useAuth();
+  const refresh = useRefreshToken();
+
+  const fetchTeams = async () => {
+    try {
+      setIsLoading(true);
+      const response = await apiClient.get("teams");
+      setTeams(response.data.data || []);
+    } catch (err) {
+      setError("Failed to fetch teams");
+      console.error(err);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const createTeam = async (teamName, teamTag) => {
+    try {
+      setIsLoading(true);
+      const response = await apiClient.post(
+        `teams/create?playerId=${auth.id}&teamName=${teamName}&teamTag=${teamTag}`
+      );
+
+      // Refresh token to get updated user data with new team info
+      await refresh();
+
+      // Get the new team ID from the response
+      const newTeamId = response.data?.data?.id;
+
+      toast.success("Team created successfully");
+
+      // Go to page my team use windows
+      window.location.href = `/my-team`;
+
+      // Return the new team ID
+      return newTeamId;
+    } catch (err) {
+      toast.error(err.response?.data?.error || "Failed to create team");
+      console.error(err);
+      return null;
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const getTeamDetails = async (teamId) => {
+    try {
+      setIsLoading(true);
+      const response = await apiClient.get(`teams/${teamId}`);
+      return response.data.data;
+    } catch (err) {
+      toast.error("Failed to fetch team details");
+      console.error(err);
+      return null;
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchTeams();
+  }, []);
+
+  return {
+    teams,
+    isLoading,
+    error,
+    createTeam,
+    getTeamDetails,
+    refreshTeams: fetchTeams,
+  };
+};


### PR DESCRIPTION
* feat: Add MyTournaments page to display user's tournaments

fix: Update PlayerMatches to correctly set team members

feat: Create PlayerTeams page for team management and creation

feat: Implement TeamDetails page to show team information and members

feat: Add TeamTournamentRounds page to view rounds of a tournament

feat: Create TournamentRegistration page for registering teams in tournaments

refactor: Update useRefreshToken to include encryptToken utility

feat: Add useTeamManagement hook for team-related operations

* feat: Enhance UI components and add confirmation dialog for tournament registration